### PR TITLE
Display Fields is False: Add Field & Field Options

### DIFF
--- a/src/options/linkContextMenu.ts
+++ b/src/options/linkContextMenu.ts
@@ -17,54 +17,48 @@ export default class linkContextMenu {
 	private createContextMenu(): void {
 		this.plugin.registerEvent(
 			this.plugin.app.workspace.on('file-menu', (menu, abstractFile, source) => {
-				if ((
-					source === "link-context-menu" ||
-					source === "calendar-context-menu" ||
-					source === 'pane-more-options' ||
-					source === 'file-explorer-context-menu')) {
 
-					const file = this.plugin.app.vault.getAbstractFileByPath(abstractFile.path);
+				const file = this.plugin.app.vault.getAbstractFileByPath(abstractFile.path);
 
-					if (file instanceof TFile && file.extension === 'md') {
-						this.file = file;
-						
-						//If fileClass
-						if (file.parent.path + "/" == this.plugin.settings.classFilesPath) {
-							menu.addSeparator();
-							menu.addItem((item) => {
-								item.setIcon("gear");
-								item.setTitle(`Manage <${file.basename}> fields`);
-								item.onClick((evt) => {
-									const fileClassAttributeSelectModal = new FileClassAttributeSelectModal(this.plugin, file);
-									fileClassAttributeSelectModal.open();
-								});
+				if (file instanceof TFile && file.extension === 'md') {
+					this.file = file;
+					
+					//If fileClass
+					if (file.parent.path + "/" == this.plugin.settings.classFilesPath) {
+						menu.addSeparator();
+						menu.addItem((item) => {
+							item.setIcon("gear");
+							item.setTitle(`Manage <${file.basename}> fields`);
+							item.onClick((evt) => {
+								const fileClassAttributeSelectModal = new FileClassAttributeSelectModal(this.plugin, file);
+								fileClassAttributeSelectModal.open();
 							});
+						});
+					} else {
+						//If displayFieldsInContextMenu true, show all fields in note
+						if (this.plugin.settings.displayFieldsInContextMenu) {
+							this.optionsList = new OptionsList(this.plugin, this.file, menu);
+							this.optionsList.createExtraOptionList();
 						} else {
-							//If displayFieldsInContextMenu true, show all fields in note
-							if(this.plugin.settings.displayFieldsInContextMenu) {
+
+							//New Field
+							if (file instanceof TFile && file.extension === 'md') {
+								this.file = file;
 								this.optionsList = new OptionsList(this.plugin, this.file, menu);
-								this.optionsList.createExtraOptionList();
-							} else {
-
-								//New Field
-								if (file instanceof TFile && file.extension === 'md') {
-									this.file = file;
-									this.optionsList = new OptionsList(this.plugin, this.file, menu);
-									this.optionsList.addSectionSelectModalOption();
-								}
-
-								//Field Options
-								menu.addItem((item) => {
-									item.setIcon("bullet-list"),
-									item.setTitle(`Field Options`),
-									item.onClick((evt) => {
-										const fieldOptions = new NoteFieldsCommandsModal(app, this.plugin, file);
-										fieldOptions.open();
-									})
-									item.setSection("target-metadata");
-								})
+								this.optionsList.addSectionSelectModalOption();
 							}
-						};
+
+							//Field Options
+							menu.addItem((item) => {
+								item.setIcon("bullet-list"),
+								item.setTitle(`Field Options`),
+								item.onClick((evt) => {
+									const fieldOptions = new NoteFieldsCommandsModal(app, this.plugin, file);
+									fieldOptions.open();
+								})
+								item.setSection("target-metadata");
+							})
+						}
 					};
 				};
 			})

--- a/src/options/linkContextMenu.ts
+++ b/src/options/linkContextMenu.ts
@@ -2,6 +2,7 @@ import { TFile } from "obsidian";
 import MetadataMenu from "main";
 import OptionsList from "src/options/OptionsList";
 import FileClassAttributeSelectModal from "src/fileClass/FileClassAttributeSelectModal";
+import NoteFieldsCommandsModal from "./NoteFieldsCommandsModal";
 
 export default class linkContextMenu {
 	private plugin: MetadataMenu;
@@ -16,14 +17,18 @@ export default class linkContextMenu {
 	private createContextMenu(): void {
 		this.plugin.registerEvent(
 			this.plugin.app.workspace.on('file-menu', (menu, abstractFile, source) => {
-				if (this.plugin.settings.displayFieldsInContextMenu && (
+				if ((
 					source === "link-context-menu" ||
 					source === "calendar-context-menu" ||
 					source === 'pane-more-options' ||
 					source === 'file-explorer-context-menu')) {
-					const file = this.plugin.app.vault.getAbstractFileByPath(abstractFile.path)
+
+					const file = this.plugin.app.vault.getAbstractFileByPath(abstractFile.path);
+
 					if (file instanceof TFile && file.extension === 'md') {
 						this.file = file;
+						
+						//If fileClass
 						if (file.parent.path + "/" == this.plugin.settings.classFilesPath) {
 							menu.addSeparator();
 							menu.addItem((item) => {
@@ -35,8 +40,30 @@ export default class linkContextMenu {
 								});
 							});
 						} else {
-							this.optionsList = new OptionsList(this.plugin, this.file, menu);
-							this.optionsList.createExtraOptionList();
+							//If displayFieldsInContextMenu true, show all fields in note
+							if(this.plugin.settings.displayFieldsInContextMenu) {
+								this.optionsList = new OptionsList(this.plugin, this.file, menu);
+								this.optionsList.createExtraOptionList();
+							} else {
+
+								//New Field
+								if (file instanceof TFile && file.extension === 'md') {
+									this.file = file;
+									this.optionsList = new OptionsList(this.plugin, this.file, menu);
+									this.optionsList.addSectionSelectModalOption();
+								}
+
+								//Field Options
+								menu.addItem((item) => {
+									item.setIcon("bullet-list"),
+									item.setTitle(`Field Options`),
+									item.onClick((evt) => {
+										const fieldOptions = new NoteFieldsCommandsModal(app, this.plugin, file);
+										fieldOptions.open();
+									})
+									item.setSection("target-metadata");
+								})
+							}
 						};
 					};
 				};


### PR DESCRIPTION
Instead of hiding _all_ metadatamenu options if the `Display field options in context menu` is toggled off, only show Add field and Field Options commands in the menu.

![Obsidian_8wYdJFwtwt](https://user-images.githubusercontent.com/54087190/181361563-4a1ace4b-e81b-4672-bfa7-4908e9cf102d.png)
