### PR TITLE
UX improvements for Multifield and Fix

### DIFF
--- a/src/fields/fieldManagers/MultiField.ts
+++ b/src/fields/fieldManagers/MultiField.ts
@@ -51,10 +51,10 @@ export default class MultiField extends AbstractListBasedField {
         when the "+" button is clicked, we display a select dropdown filtered with remaining options. when one option is selected we add it to the list and remove the control
         */
         let valueHovered = false;
-		let currentValues = [];
-		if(p[this.field.name]){
-			currentValues = p[this.field.name].split(",").map((v) => v.trim());
-		}
+        let currentValues: string[] = [];
+        if (p[this.field.name]) {
+            currentValues = p[this.field.name].split(",").map((v: string) => v.trim());
+        }
 
         /* select container */
         const selectContainer = document.createElement("div");
@@ -92,17 +92,17 @@ export default class MultiField extends AbstractListBasedField {
                 fieldContainer.removeChild(selectContainer);
             }
         }
-		const closeSelect = document.createElement("button");
-		closeSelect.setText("\u274C");
-		closeSelect.addClass("metadata-menu-dv-field-button");
-		closeSelect.addClass("multi");
-		closeSelect.onclick = () => {
-		  fieldContainer.appendChild(valuesContainer);
-		  fieldContainer.appendChild(singleSpacer);
-		  fieldContainer.appendChild(doubleSpacer);
-		  fieldContainer.removeChild(selectContainer);
-		};
-		selectContainer.appendChild(closeSelect);
+        const closeSelect = document.createElement("button");
+        closeSelect.setText("\u274C");
+        closeSelect.addClass("metadata-menu-dv-field-button");
+        closeSelect.addClass("multi");
+        closeSelect.onclick = () => {
+            fieldContainer.appendChild(valuesContainer);
+            fieldContainer.appendChild(singleSpacer);
+            fieldContainer.appendChild(doubleSpacer);
+            fieldContainer.removeChild(selectContainer);
+        };
+        selectContainer.appendChild(closeSelect);
 
         /* current values container */
         const valuesContainer = document.createElement("div");

--- a/src/fields/fieldManagers/MultiField.ts
+++ b/src/fields/fieldManagers/MultiField.ts
@@ -92,6 +92,17 @@ export default class MultiField extends AbstractListBasedField {
                 fieldContainer.removeChild(selectContainer);
             }
         }
+		const closeSelect = document.createElement("button");
+		closeSelect.setText("\u274C");
+		closeSelect.addClass("metadata-menu-dv-field-button");
+		closeSelect.addClass("multi");
+		closeSelect.onclick = () => {
+		  fieldContainer.appendChild(valuesContainer);
+		  fieldContainer.appendChild(singleSpacer);
+		  fieldContainer.appendChild(doubleSpacer);
+		  fieldContainer.removeChild(selectContainer);
+		};
+		selectContainer.appendChild(closeSelect);
 
         /* current values container */
         const valuesContainer = document.createElement("div");

--- a/src/fields/fieldManagers/MultiField.ts
+++ b/src/fields/fieldManagers/MultiField.ts
@@ -51,7 +51,10 @@ export default class MultiField extends AbstractListBasedField {
         when the "+" button is clicked, we display a select dropdown filtered with remaining options. when one option is selected we add it to the list and remove the control
         */
         let valueHovered = false;
-        const currentValues = (p[this.field.name] as string).split(",").map(v => v.trim());
+		let currentValues = [];
+		if(p[this.field.name]){
+			currentValues = p[this.field.name].split(",").map((v) => v.trim());
+		}
 
         /* select container */
         const selectContainer = document.createElement("div");

--- a/styles.css
+++ b/styles.css
@@ -259,6 +259,7 @@
 
 .metadata-menu-dv-multi-values-container {
     display: flex;
+	min-height: 1.0em;
 }
 
 .metadata-menu-dv-multi-value-container{


### PR DESCRIPTION
Previously the plugin would crash when a multifield was present in a file but lacked values, this should be fixed with this PR.

In addition I added:
- A close button for the Multifield Selection
- The functionality that the selection button for Multifields is present when the field exists in the field but is empty.

![grafik](https://user-images.githubusercontent.com/49754596/183265263-83a7ef12-a751-4c38-9380-6a42a3868fe2.png)

![grafik](https://user-images.githubusercontent.com/49754596/183265308-69c56a07-08cc-4dd6-b1a8-1eecd6adaaae.png)
