### PR TITLE
setPlaceholder instead of setValue allows for faster input

### DIFF
--- a/src/optionModals/fields/DateModal.ts
+++ b/src/optionModals/fields/DateModal.ts
@@ -112,7 +112,8 @@ export default class DateModal extends Modal {
         const inputContainer = form.createDiv({ cls: "metadata-menu-dateinput-with-picker" })
         this.inputEl = new TextComponent(inputContainer);
         this.inputEl.inputEl.focus();
-        this.inputEl.setValue(this.value.replace(/^\[\[/g, "").replace(/\]\]$/g, "").split("|").first()?.split("/").last() || "");
+        let currentDateValue = this.value.replace(/^\[\[/g, "").replace(/\]\]$/g, "").split("|").first()?.split("/").last();
+        this.inputEl.setPlaceholder(currentDateValue || "");
         this.inputEl.inputEl.addClass("metadata-menu-prompt-input");
         this.inputEl.onChange(value => {
             this.inputEl.inputEl.removeClass("is-invalid")


### PR DESCRIPTION
Very simple suggestion: changing `this.inputEl.setValue` to `this.inputEl.setPlaceholder` will let the user start entering a new value right away, instead of having to remove the value and then start entering text. 

I add the line `let currentDateValue = this.value.replace(/^\[\[/g, "").replace(/\]\]$/g, "").split("|").first()?.split("/").last();` and then use the variable `currentDateValue` in `setPlaceholder` because the `.replace` actions were causing the input field to render the placeholder as inputted text.

I haven't thoroughly tested this, but I think it works!