### PR TITLE
Add tests for metadata

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -6,24 +6,10 @@ export class Setting { };
 /** Credit to @blacksmithgu for obsidian mocks in dataview */
 /** Basic obsidian abstraction for any file or folder in a vault. */
 export abstract class TAbstractFile {
-    /**
-     * @public
-     */
-    path: string;
-    /**
-     * @public
-     */
-    name: string;
 }
 
 /** Tracks file created/modified time as well as file system size. */
 export interface FileStats {
-    /** @public */
-    ctime: number;
-    /** @public */
-    mtime: number;
-    /** @public */
-    size: number;
 }
 
 /** A regular file in the vault. */
@@ -34,15 +20,8 @@ export class TFile extends TAbstractFile {
     static [Symbol.hasInstance](instance: any) {
         return instance.hasOwnProperty("extension");
     }
-
-    stat: FileStats;
-
-    basename: string;
-
-    extension: string;
 }
 
 /** A folder in the vault. */
-export class TFolder extends TAbstractFile {
-    children: TAbstractFile[];
+export class TFolder {
 }

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,48 @@
+export class FuzzySuggestModal { };
+export class SuggestModal { };
+export class Modal { };
+export class Setting { };
+
+/** Credit to @blacksmithgu for obsidian mocks in dataview */
+/** Basic obsidian abstraction for any file or folder in a vault. */
+export abstract class TAbstractFile {
+    /**
+     * @public
+     */
+    path: string;
+    /**
+     * @public
+     */
+    name: string;
+}
+
+/** Tracks file created/modified time as well as file system size. */
+export interface FileStats {
+    /** @public */
+    ctime: number;
+    /** @public */
+    mtime: number;
+    /** @public */
+    size: number;
+}
+
+/** A regular file in the vault. */
+export class TFile extends TAbstractFile {
+    /** instanceof tests do not pass without 
+     * this alternate implementation
+     */
+    static [Symbol.hasInstance](instance: any) {
+        return instance.hasOwnProperty("extension");
+    }
+
+    stat: FileStats;
+
+    basename: string;
+
+    extension: string;
+}
+
+/** A folder in the vault. */
+export class TFolder extends TAbstractFile {
+    children: TAbstractFile[];
+}

--- a/src/commands/getValues.ts
+++ b/src/commands/getValues.ts
@@ -1,5 +1,5 @@
 import MetadataMenu from "main";
-import { TFile } from "obsidian"
+import { TFile } from "obsidian";
 import { inlineFieldRegex, encodeLink, decodeLink } from "src/utils/parser";
 
 export async function getValues(plugin: MetadataMenu, fileOrfilePath: TFile | string, attribute: string): Promise<string[]> {

--- a/src/fields/fieldManagers/DateField.ts
+++ b/src/fields/fieldManagers/DateField.ts
@@ -1,5 +1,6 @@
 import MetadataMenu from "main";
-import { Menu, moment, setIcon, TextComponent, TFile, ToggleComponent } from "obsidian";
+import moment from "moment";
+import { Menu, setIcon, TextComponent, TFile, ToggleComponent } from "obsidian";
 import FieldCommandSuggestModal from "src/options/FieldCommandSuggestModal";
 import DateModal from "src/optionModals/fields/DateModal";
 import { FieldIcon, FieldType } from "src/types/fieldTypes";

--- a/src/optionModals/fields/DateModal.ts
+++ b/src/optionModals/fields/DateModal.ts
@@ -3,7 +3,7 @@ import { insertValues } from "src/commands/insertValues";
 import { replaceValues } from "src/commands/replaceValues";
 import Field from "src/fields/Field";
 import { FieldManager as FM } from "src/fields/FieldManager";
-import { moment } from "obsidian";
+import moment from "moment";
 import flatpickr from "flatpickr";
 import MetadataMenu from "main";
 import { FieldIcon, FieldType, FieldManager } from "src/types/fieldTypes";

--- a/src/settings/MetadataMenuSettingTab.ts
+++ b/src/settings/MetadataMenuSettingTab.ts
@@ -1,4 +1,5 @@
-import { PluginSettingTab, Setting, ButtonComponent, ToggleComponent, Modal, DropdownComponent, moment, setIcon } from "obsidian";
+import { PluginSettingTab, Setting, ButtonComponent, ToggleComponent, Modal, DropdownComponent, setIcon } from "obsidian";
+import moment from "moment";
 import MetadataMenu from "main";
 import FieldSettingsModal from "src/settings/FieldSettingsModal";
 import Field from "src/fields/Field";

--- a/src/tests/ResponseMocks/Kimi no Na wa (2016).md
+++ b/src/tests/ResponseMocks/Kimi no Na wa (2016).md
@@ -1,0 +1,23 @@
+---
+type: "movie"
+subType: "movie"
+title: "Kimi no Na wa."
+englishTitle: "Your Name."
+year: 2016
+dataSource: "MALAPI"
+url: "https://myanimelist.net/anime/32281/Kimi_no_Na_wa"
+id: 32281
+genres: 
+  - "Drama"
+  - "Supernatural"
+producer: "CoMix Wave Films"
+duration: "1 hr 46 min"
+onlineRating: 8.86
+image: "https://cdn.myanimelist.net/images/anime/5/87048.jpg"
+released: true
+premiere: "8/26/2016"
+watched: false
+lastWatched: ""
+personalRating: 0
+tags: "#mediaDB/tv/movie"
+---

--- a/src/tests/ResponseMocks/KimiNoNaWaMetadataCache.json
+++ b/src/tests/ResponseMocks/KimiNoNaWaMetadataCache.json
@@ -1,0 +1,55 @@
+{
+    "sections": [
+        {
+            "type": "yaml",
+            "position": {
+                "start": {
+                    "line": 0,
+                    "col": 0,
+                    "offset": 0
+                },
+                "end": {
+                    "line": 22,
+                    "col": 3,
+                    "offset": 474
+                }
+            }
+        }
+    ],
+    "frontmatter": {
+        "type": "movie",
+        "subType": "movie",
+        "title": "Kimi no Na wa.",
+        "englishTitle": "Your Name.",
+        "year": 2016,
+        "dataSource": "MALAPI",
+        "url": "https://myanimelist.net/anime/32281/Kimi_no_Na_wa",
+        "id": 32281,
+        "genres": [
+            "Drama",
+            "Supernatural"
+        ],
+        "producer": "CoMix Wave Films",
+        "duration": "1 hr 46 min",
+        "onlineRating": 8.86,
+        "image": "https://cdn.myanimelist.net/images/anime/5/87048.jpg",
+        "released": true,
+        "premiere": "8/26/2016",
+        "watched": false,
+        "lastWatched": "",
+        "personalRating": 0,
+        "tags": "#mediaDB/tv/movie",
+        "position": {
+            "start": {
+                "line": 0,
+                "col": 0,
+                "offset": 0
+            },
+            "end": {
+                "line": 22,
+                "col": 3,
+                "offset": 474
+            }
+        }
+    }
+}

--- a/src/tests/ResponseMocks/KimiNoNaWaTFile.json
+++ b/src/tests/ResponseMocks/KimiNoNaWaTFile.json
@@ -1,0 +1,11 @@
+{
+    "path": "Media DB/Kimi no Na wa (2016).md",
+    "name": "Kimi no Na wa (2016).md",
+    "basename": "Kimi no Na wa (2016)",
+    "extension": "md",
+    "stat": {
+        "ctime": 1665233725400,
+        "mtime": 1665236198538,
+        "size": 475
+    }
+}

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -1,0 +1,41 @@
+import MetadataMenu from "main";
+import { App, TFile } from "obsidian";
+import { MetadataMenuApi } from "src/MetadataMenuApi";
+import kimiNoNaWaMetadataMock from "./ResponseMocks/KimiNoNaWaMetadataCache.json"
+import { readFileSync } from "fs";
+import kimiNoNaWaTFile from "./ResponseMocks/KimiNoNaWaTFile.json";
+import path from "path";
+
+let mockFileContents: string;
+let mockPlugin: MetadataMenu;
+let mockAppGenerator: (tfile: TFile, fileContents: string, fileMetadata: any) => App;
+
+beforeAll(() => {
+    mockAppGenerator = (tfile: TFile, fileContents: string, fileMetadata: any) => {
+        return {
+            app: {
+                vault: {
+                    getAbstractFileByPath: (_path: string): TFile => {
+                        return tfile;
+                    },
+                    cachedRead: async (_tfile: TFile): Promise<string> => { return fileContents; }
+                },
+                metadataCache: {
+                    getFileCache: (_tfile: TFile): any => { return fileMetadata; }
+                }
+            }
+        } as unknown as App;
+    }
+})
+
+test('getting metadata from Kimi no Na Wa', async () => {
+    const castedTFile = kimiNoNaWaTFile as TFile;
+    mockFileContents = readFileSync(path.resolve(__dirname, './ResponseMocks/Kimi no Na wa (2016).md')).toLocaleString();
+    mockPlugin = { ...mockAppGenerator(castedTFile, mockFileContents, kimiNoNaWaMetadataMock) } as unknown as MetadataMenu;
+    const api = new MetadataMenuApi(mockPlugin).make();
+    expect(api.getValues(castedTFile, "title")).resolves.toEqual('Kimi no Na wa.');
+    expect(api.getValues(castedTFile, "name")).resolves.toEqual(undefined);
+    expect(api.getValues(castedTFile, "genres")).resolves.toEqual(['Drama', 'Supernatural']);
+    expect(api.getValues(castedTFile, "personalRating")).resolves.toEqual(0);
+    expect(api.getValues(castedTFile, "watch")).resolves.toEqual(false);
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
 	"strictNullChecks": true,
     "lib": [
       "DOM",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
 	"strictNullChecks": true,
     "lib": [
       "DOM",


### PR DESCRIPTION
I've added a few tests based on the behavior I'd expect from the Obsidian API. Your spec seems to differ a bit and so the tests fail. We should discuss that a bit.

- Opted to create an `App` generator so we can dynamically set responses. This is actually directly possible using jest's `mockResponseOnce` but I couldn't figure it out for the life of me. If you know how to do it, let me know and I'll rewrite accordingly.
- Created JSON modules to separate out the responses
- The md file seems useless IMO. Will remove probably.