### PR TITLE
181 fix table view when using fileClass alias or tag mapping

### DIFF
--- a/src/fileClass/fileClassTableView.ts
+++ b/src/fileClass/fileClassTableView.ts
@@ -203,6 +203,13 @@ export class FileClassTableView {
     }
 
     private buildDvJSQuery(): string {
+        const tagsMappedToFileClass: string[] = []
+        this.plugin.fieldIndex.tagsMatchingFileClasses.forEach((cls, tag) => {
+            if (this.fileClass === cls) {
+                tagsMappedToFileClass.push('#' + tag)
+            }
+        })
+
         let dvQuery = "";
         const fileClassAlias = this.plugin.settings.fileClassAlias
         const classFilesPath = this.plugin.settings.classFilesPath
@@ -212,7 +219,7 @@ export class FileClassTableView {
         (
             (typeof(p['${fileClassAlias}']) === 'string' && p['${fileClassAlias}'] === '${this.fileClass.name}')
             || (Array.isArray(p['${fileClassAlias}']) && p['${fileClassAlias}'].includes('${this.fileClass.name}'))
-            || p.file.etags.values.includes('#${this.fileClass.name}')
+            || p.file.etags.values.some(et => ${JSON.stringify(tagsMappedToFileClass)}.some(t => et.startsWith(t)))
         )
         ${!!classFilesPath ? "        && !p.file.path.includes('" + classFilesPath + "')\n" : ""}
         ${templatesFolder ? "        && !p.file.path.includes('" + templatesFolder + "')\n" : ""}

--- a/src/fileClass/fileClassTableView.ts
+++ b/src/fileClass/fileClassTableView.ts
@@ -204,18 +204,19 @@ export class FileClassTableView {
 
     private buildDvJSQuery(): string {
         let dvQuery = "";
+        const fileClassAlias = this.plugin.settings.fileClassAlias
         const classFilesPath = this.plugin.settings.classFilesPath
         const templatesFolder = this.plugin.app.plugins.plugins["templater-obsidian"]?.settings["templates_folder"];
         dvQuery += `dv.pages()\n`;
-        dvQuery += `    .where(p => \n` +
-            `        (\n` +
-            `            (typeof(p.fileClass) === 'string' && p.fileClass === '${this.fileClass.name}') \n` +
-            `            || (Array.isArray(p.fileClass) && p.fileClass.includes('${this.fileClass.name}')) \n` +
-            `            || p.file.etags.values.includes('#${this.fileClass.name}')\n` +
-            `        )\n` +
-            `${!!classFilesPath ? "        && !p.file.path.includes('" + classFilesPath + "')\n" : ""}` +
-            `${templatesFolder ? "        && !p.file.path.includes('" + templatesFolder + "')\n" : ""}` +
-            `    )\n`;
+        dvQuery += `    .where(p =>
+        (
+            (typeof(p['${fileClassAlias}']) === 'string' && p['${fileClassAlias}'] === '${this.fileClass.name}')
+            || (Array.isArray(p['${fileClassAlias}']) && p['${fileClassAlias}'].includes('${this.fileClass.name}'))
+            || p.file.etags.values.includes('#${this.fileClass.name}')
+        )
+        ${!!classFilesPath ? "        && !p.file.path.includes('" + classFilesPath + "')\n" : ""}
+        ${templatesFolder ? "        && !p.file.path.includes('" + templatesFolder + "')\n" : ""}
+        )`;
         dvQuery += this.buildFilterQuery();
         return dvQuery;
     }


### PR DESCRIPTION
- Interpolate `fileClassAlias` variable in the buildDvJSQuery() string builder instead of using fileClass

- Build in an array the list of tags mapped to the current file class.
- Then, check on each page we filter that it contains at least one tag that starts with one of the tags in the built array.

For the second point, I'm sure it's not ideal but it's the only way I've found to retrieve the tags associated with the current file class.