### PR TITLE
Fix: TypeError due to "null" usage

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -132,7 +132,7 @@ export default class MetadataMenu extends Plugin {
 			this.codeBlockListManager.addChild(fileClassCodeBlockManager)
 			ctx.addChild(fileClassCodeBlockManager)
 		});
-		this.app.workspace.trigger("layout-change")
+		if (this.app.workspace.layoutReady) this.app.workspace.trigger("layout-change")
 		this.testRunner = this.addChild(new TestRunner(this))
 		if (MDM_DEBUG && this.app.vault.getName() === 'test-vault-mdm') { MDM_DEBUG = false; await this.testRunner.run() }
 	};


### PR DESCRIPTION
![image](https://github.com/mdelobelle/metadatamenu/assets/559564/4d69f5ce-9dfe-48f2-8be3-8baf1328d6a1)

I've step debugged this to come to this solution. now the plugin loads clean when obsidian starts.