### PR TITLE
Bug: Field initialized to 0 is not rendered by fieldModifier

### DIFF
--- a/src/fields/models/Number.ts
+++ b/src/fields/models/Number.ts
@@ -231,7 +231,7 @@ export function createDvField(
     attrs.cls = "value-container"
     /* button to display input */
     const editBtn = fieldContainer.createEl("button");
-    const fieldValue = (dv.el('span', managedField.value || "", attrs) as HTMLDivElement);
+    const fieldValue = (dv.el('span', managedField.value ?? "", attrs) as HTMLDivElement);
     fieldContainer.appendChild(fieldValue);
 
     /* end spacer */


### PR DESCRIPTION
When a field in the frontmatter is set to 0, using the fieldModifier function does not display the value. Instead, it renders an empty space. This appears to be due to a falsy check that treats 0 as if it were undefined.

Steps to Reproduce:

Create a markdown file with the following frontmatter:

```
---
MyField: 0
---
```
Open the file in Obsidian and run the following DataviewJS snippet:

```
dataviewjs
const { fieldModifier: f } = MetadataMenu.api;
f(dv, dv.current(), "MyField");
```

Notice that the field for "MyField" renders as an empty space instead of displaying 0.

**Expected Behavior:**
The field should render the numeric value 0 clearly.

**Actual Behavior:**
The field renders as empty space because the code uses a falsy check (for example, value || ""), which treats 0 as false.

**Potential Fix:**
A possible fix is to change the fallback logic to use the nullish coalescing operator (??) or an explicit check for undefined/null. For example, replacing:


`const displayValue = dv.el("span", someValue || "", attrs);`

with:

`const displayValue = dv.el("span", someValue ?? "", attrs);`

would allow 0 to be rendered correctly.

_Environment:_

Metadata-menu plugin version: 0.8.7
Obsidian version: 1.8.9
OS: Windows 11

_Additional Context:_
This issue seems to be a common pitfall in JavaScript where falsy values like 0 are not distinguished from undefined values. Using a nullish check should resolve the issue.