### PR TITLE
Fix incorrect type om CanvasGroupLink

### DIFF
--- a/src/fields/models/CanvasGroupLink.ts
+++ b/src/fields/models/CanvasGroupLink.ts
@@ -7,7 +7,7 @@ import { ISettingsModal } from "../base/BaseSetting";
 import * as AbstractCanvas from "./abstractModels/AbstractCanvas";
 
 export class Base implements IFieldBase {
-    type = <const>"CanvasGroup"
+    type = <const>"CanvasGroupLink"
     tagName = "canvas-links"
     icon = "box-select"
     tooltip = "Updates with groups in canvas"


### PR DESCRIPTION
Canvas Group is not working due do it's type being incorrect in the definition, being the same as CanvasGroup is causing conflicts