### PR TITLE
Fix: Plugin initialization for already-open files

### DIFF
--- a/src/options/updateProps.ts
+++ b/src/options/updateProps.ts
@@ -59,7 +59,7 @@ export async function updatePropertiesSection(plugin: MetadataMenu) {
     const leaves = plugin.app.workspace.getLeavesOfType("markdown");
     for (const leaf of leaves) {
         const view = leaf.view
-        if (!(view instanceof MarkdownView) || !(view.file instanceof TFile) || view.file === undefined) return
+        if (!(view instanceof MarkdownView) || !(view.file instanceof TFile) || view.file === undefined) continue
         const file = view.file
         if (!plugin.app.vault.getAbstractFileByPath(file.path)) continue
         updateProps(plugin, view, file)


### PR DESCRIPTION
## Problem

The plugin was experiencing initialization issues where it would not work on files that were already open when the vault loaded:

- Plugin completely failed to work after opening vault with previous session's files
- Required closing all files before plugin would activate
- Very frustrating user experience when opening vault with multiple tabs from previous session

## Root Causes

Two issues were identified:

### 1. Timing Issue
Plugin was indexing immediately during `onload()`, before the Obsidian workspace was fully initialized. This caused race conditions where already-open files weren't recognized.

### 2. Loop Exit Bug
In `updatePropertiesSection()`, using `return` instead of `continue` caused the loop to exit early when encountering any non-MarkdownView leaf (like graph view, file explorer, etc.), preventing subsequent markdown files from being processed.

## Solution

### 1. Defer Initialization (`main.ts`)

Moved indexing and plugin activation into `workspace.onLayoutReady()` callback:

```typescript
this.app.workspace.onLayoutReady(async () => {
    await this.fieldIndex.fullIndex()
    this.launched = true
    addCommands(this)
    
    // Process all already-open files
    const leaves = this.app.workspace.getLeavesOfType("markdown");
    leaves.forEach((leaf) => {
        if (leaf.view instanceof MarkdownView) {
            this.indexStatus.checkForUpdate(leaf.view);
        }
    });
    
    this.app.workspace.trigger("layout-change")
    
    // Wait for next render cycle to ensure metadataEditor is fully rendered
    requestAnimationFrame(() => {
        requestAnimationFrame(() => {
            updatePropertiesCommands(this);
        });
    });
})
```

**Why this works:**
- Waits for workspace to be fully initialized before indexing
- Explicitly processes all already-open markdown files after indexing
- Uses `requestAnimationFrame` to ensure DOM elements are rendered before updating properties

### 2. Fix Loop Bug (`src/options/updateProps.ts`)

Changed `return` to `continue` to process all markdown views:

```typescript
// Before
if (!(view instanceof MarkdownView) || !(view.file instanceof TFile) || view.file === undefined) return

// After
if (!(view instanceof MarkdownView) || !(view.file instanceof TFile) || view.file === undefined) continue
```

**Why this matters:**
- The `return` statement was exiting the entire function when encountering any non-markdown tab
- With `continue`, the loop properly skips non-markdown tabs and processes all valid markdown views

## Changes

### `main.ts`
- Removed immediate `await this.fieldIndex.fullIndex()` call (line ~121)
- Removed immediate `this.launched = true` and `addCommands(this)` calls (lines ~126-128)
- Removed immediate `this.app.workspace.trigger("layout-change")` call (line ~137)
- Wrapped all initialization in `workspace.onLayoutReady()` callback with proper sequencing
- Added explicit processing of already-open markdown files
- Added `requestAnimationFrame` timing to ensure metadataEditor DOM is ready

### `src/options/updateProps.ts`
- Fixed critical bug: changed `return` to `continue` on line 62

## Testing

- **Mobile**: Plugin now works immediately when opening vault with previous session's files
- **Desktop**: All already-open files are recognized without manual interaction
- **Build**: Compiles successfully with no errors
- **Existing tests**: Test suite remains compatible (tests manually control indexing)

## Initialization Flow

### Before
```
onload() → index immediately → setup components → register commands
         ↓
    Race condition: workspace may not be ready
         ↓
    Already-open files not recognized
```

### After
```
onload() → setup components → register onLayoutReady callback
                                      ↓
                          workspace.onLayoutReady fires
                                      ↓
                          index → register commands → process open files
                                      ↓
                          All files recognized and activated
```

## Breaking Changes

**None.** This is a pure bug fix that improves initialization behavior without changing the API or feature set.

## Additional Context

- The test suite (`src/testing/runner.ts`) is unaffected because it manually calls `fullIndex()` and controls timing explicitly, independent of the plugin's initialization flow
- The `onLayoutReady` callback is a standard Obsidian API pattern for plugins that need to interact with the workspace
- Both bugs were necessary to fix: the timing issue caused the problem, and the loop bug prevented the solution from working properly