### PR TITLE
Fix PDF freeze issue (#660) - prevent properties processing on non-markdown files

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -109,7 +109,9 @@ export default class MetadataMenu extends Plugin {
 
 		this.registerEvent(
 			this.app.workspace.on("file-open", (file) => {
-				updatePropertiesCommands(this)
+				if (file instanceof TFile && file.extension === "md") {
+					updatePropertiesCommands(this)
+				}
 			})
 		)
 

--- a/src/options/updateProps.ts
+++ b/src/options/updateProps.ts
@@ -115,7 +115,10 @@ export async function updatePropertiesPane(plugin: MetadataMenu) {
 
 export async function updatePropertiesCommands(plugin: MetadataMenu) {
     if (plugin.settings.enableProperties) {
-        updatePropertiesSection(plugin)
-        updatePropertiesPane(plugin)
+        const activeFile = plugin.app.workspace.getActiveFile()
+        if (activeFile instanceof TFile && activeFile.extension === "md") {
+            updatePropertiesSection(plugin)
+            updatePropertiesPane(plugin)
+        }
     }
 }


### PR DESCRIPTION
## Fixes
Fixes #660 - Obsidian freezes when opening PDF files

Added file type check in `file-open` event listener (main.ts) and in `updatePropertiesCommands` (updateProps.ts) so that properties processing only runs for `.md` files.