### PR TITLE
Fix/fileclass array format corruption

### DIFF
--- a/src/fields/Field.ts
+++ b/src/fields/Field.ts
@@ -349,7 +349,8 @@ export function getFieldConstructor<O extends BaseOptions>(id: string, fileClass
         for (const [index, fC] of fileClasses.entries()) {
             valuesList[`${index}`] = fC
         }
-        return [buildField(plugin, plugin.settings.fileClassAlias, id, "", undefined, undefined, undefined, undefined, ...["Select", options] as FieldParam), "Select"]
+        const fieldType = plugin.settings.fileClassAsMultiSelect ? "Multi" : "Select";
+        return [buildField(plugin, plugin.settings.fileClassAlias, id, "", undefined, undefined, undefined, undefined, ...[fieldType, options] as FieldParam), fieldType as FieldType]
     } else {
         const fS = plugin.settings.presetFields.find(f => f.id === id)
         if (!fS) return []

--- a/src/note/lineNode.ts
+++ b/src/note/lineNode.ts
@@ -157,7 +157,8 @@ export class LineNode {
                     }
                     if (yamlAttr === this.plugin.settings.fileClassAlias) {
                         const fileClasses = [...this.plugin.fieldIndex.fileClassesName.keys()].sort()
-                        const fileClassField = new (buildEmptyField(this.plugin, undefined, "Select"))
+                        const fieldType = this.plugin.settings.fileClassAsMultiSelect ? "Multi" : "Select";
+                        const fileClassField = new (buildEmptyField(this.plugin, undefined, fieldType))
                         const valuesList: Record<string, string> = {}
                         const options = {
                             sourceType: "ValuesList",

--- a/src/note/note.ts
+++ b/src/note/note.ts
@@ -269,10 +269,26 @@ export class Note {
         if (id.startsWith("fileclass-field")) {
             const fR = id.match(/fileclass-field-(?<fileClassAlias>.*)/)
             if (fR?.groups?.fileClassAlias) {
-                const content = `${fR.groups.fileClassAlias}: ${payload.value}`
+                let content: string;
+
+                // Check if this fileClass field should be treated as Multi type
+                const field = this.getField(id);
+                const isMultiType = field?.type === "Multi" || this.plugin.settings.fileClassAsMultiSelect;
+
+                if (isMultiType && payload.value.includes(",")) {
+                    // Format as array for Multi type
+                    const values = payload.value
+                        .replace(/(\,\s+)/g, ',')
+                        .split(',')
+                        .filter(v => !!v.trim())
+                        .map(v => v.trim());
+                    content = `${fR.groups.fileClassAlias}: [${values.join(', ')}]`;
+                } else {
+                    content = `${fR.groups.fileClassAlias}: ${payload.value}`;
+                }
+
                 const newLine = new Line(this.plugin, this, "yaml", content, 1)
                 newLine.renderLine(asList, asBlockquote)
-
             }
             return
         }

--- a/src/options/updateProps.ts
+++ b/src/options/updateProps.ts
@@ -24,7 +24,9 @@ const updateProps = async (plugin: MetadataMenu, view: MarkdownView | PropView, 
             id: key === plugin.settings.fileClassAlias ?
                 `fileclass-field-${plugin.settings.fileClassAlias}` :
                 plugin.fieldIndex.filesFields.get(file.path)?.find(_f => _f.isRoot() && _f.name === key)?.id,
-            type: key === plugin.settings.fileClassAlias ? "Select" : plugin.fieldIndex.filesFields.get(file.path)?.find(_f => _f.isRoot() && _f.name === key)?.type
+            type: key === plugin.settings.fileClassAlias ?
+                (plugin.settings.fileClassAsMultiSelect ? "Multi" : "Select") :
+                plugin.fieldIndex.filesFields.get(file.path)?.find(_f => _f.isRoot() && _f.name === key)?.type
         }
         if (!pseudoField.id || !pseudoField.type) return
         const node = note.getNodeForIndexedPath(pseudoField.id)

--- a/src/settings/MetadataMenuSettingTab.ts
+++ b/src/settings/MetadataMenuSettingTab.ts
@@ -573,9 +573,23 @@ export default class MetadataMenuSettingTab extends PluginSettingTab {
 		maxRows.settingEl.addClass("narrow-title");
 		maxRows.controlEl.addClass("full-width");
 		maxRows.settingEl.appendChild(rowPerPageSaveButton.buttonEl)
+		
+		const fileClassAsMultiSelect = new Setting(classFilesSettings.containerEl)
+			.setName('FileClass as MultiSelect')
+			.setDesc('Allow selecting multiple fileClass values instead of just one')
+			.addToggle((cb) => {
+				cb
+					.setValue(this.plugin.settings.fileClassAsMultiSelect)
+					.onChange(async (value) => {
+						this.plugin.settings.fileClassAsMultiSelect = value;
+						await this.plugin.saveSettings();
+					});
+			})
+		fileClassAsMultiSelect.settingEl.addClass("no-border");
+		fileClassAsMultiSelect.controlEl.addClass("full-width");
 
 		/* Choose fileclass at file creation Fileclass selector in modal*/
-
+			
 		const chooseFileClassAtFileCreation = new Setting(classFilesSettings.containerEl)
 			.setName('Add a fileclass after create')
 			.setDesc('Select a fileclass at file creation to be added to the file')

--- a/src/settings/MetadataMenuSettings.ts
+++ b/src/settings/MetadataMenuSettings.ts
@@ -14,6 +14,7 @@ export interface MetadataMenuSettings {
 	classFilesPath: string | null;
 	isAutosuggestEnabled: boolean;
 	fileClassAlias: string;
+	fileClassAsMultiSelect: boolean;
 	settingsVersion?: string | number;
 	globalFileClass?: string;
 	firstDayOfWeek: number;
@@ -49,6 +50,7 @@ export const DEFAULT_SETTINGS: MetadataMenuSettings = {
 	classFilesPath: null,
 	isAutosuggestEnabled: true,
 	fileClassAlias: "fileClass",
+	fileClassAsMultiSelect: false,
 	settingsVersion: undefined,
 	globalFileClass: undefined,
 	firstDayOfWeek: 1,


### PR DESCRIPTION
I wanted to restructure my vault. I needed each category to have subcategories, but with separate prompts for each subcategory under the main category. I also wanted to store information in the properties indicating that a note is external, using the `fileclass External`. 

In the documentation, I [found](https://mdelobelle.github.io/metadatamenu/fileclasses/#basic-mapping) that it’s possible to assign multiple `fileClass` values to a file. When I tried using this feature, it only worked in source mode. 

So, I made the necessary adjustments to ensure it worked **in live preview mode as well**. You can see an example of how it works in the screenshot.

<img width="495" height="197" alt="image" src="https://github.com/user-attachments/assets/ed7eb99d-0a88-4727-b8c1-d6428e08fee7" />
