### PR TITLE
Fix: identify nested tags in fileclass tag mapping

### DIFF
--- a/src/index/FieldIndex.ts
+++ b/src/index/FieldIndex.ts
@@ -1,4 +1,4 @@
-import { Notice, TFile } from "obsidian"
+import { Notice, TFile, getAllTags } from "obsidian"
 import MetadataMenu from "main"
 import { FileClass, createFileClass, getFileClassNameFromPath, indexFileClass } from "src/fileClass/fileClass";
 import FileClassQuery from "src/fileClass/FileClassQuery";
@@ -372,21 +372,14 @@ export default class FieldIndex extends FieldIndexBuilder {
     private resolveFileClassMatchingTags(): void {
 
         if (!this.tagsMatchingFileClasses.size) return
-        const mappedTags = [...this.tagsMatchingFileClasses.keys()].map(_t => `#${_t}`)
+        const mappedTags = new Set(
+            Array.from(this.tagsMatchingFileClasses.keys(), _t => `#${_t}`)
+        )
         const filesWithMappedTag: cFileWithTags[] = [];
         this.indexableFiles().forEach(_f => {
-            const cache = this.plugin.app.metadataCache.getFileCache(_f)
-            const cachedTags = cache?.frontmatter?.tags
-            let fileTags: string[] = []
-            if (Array.isArray(cachedTags)) {
-                fileTags = cachedTags
-            } else if (typeof cachedTags === "string") {
-                fileTags = cachedTags.split(",").map(_t => _t.trim())
-            }
-            const filteredTagsFromFrontmatter = fileTags.filter(_t => mappedTags.includes(`#${_t}`))
-            const filteredTagsFromFile = cache?.tags?.filter(_t => mappedTags.includes(_t.tag)).map(_t => _t.tag) || []
-            const filteredTags = filteredTagsFromFrontmatter.concat(filteredTagsFromFile)
-            if (filteredTags?.length) {
+            const fileTags = this.getExpandedTags(_f)
+            const filteredTags = Array.from(fileTags).filter(_t => mappedTags.has(_t))
+            if (filteredTags.length) {
                 const fileWithTags: cFileWithTags = { path: _f.path, tags: [] }
                 filteredTags.forEach(_t => fileWithTags.tags.push(_t))
                 filesWithMappedTag.push(fileWithTags)
@@ -403,6 +396,27 @@ export default class FieldIndex extends FieldIndexBuilder {
                 )
             })
         })
+    }
+
+    private getExpandedTags(file: TFile): Set<string> {
+        /*
+         Returns a set of every tag within a file. Nested tags like #my/nested/tag are
+         expanded into all parent levels: #my, #my/nested, #my/nested/tag.
+
+         Analogous to dataview's file.tags, rather than file.etags.
+         */
+        const fileCache = this.plugin.app.metadataCache.getFileCache(file)
+        if (!fileCache) return new Set()
+
+        const exactTags = new Set(getAllTags(fileCache))
+        const allExpandedTags = new Set<string>()
+        for (const tag of exactTags) {
+            const tagLevels = tag.replace(/^#/, "").split("/")
+            for (let i = 0; i < tagLevels.length; i++) {
+                allExpandedTags.add(`#${tagLevels.slice(0, i + 1).join("/")}`)
+            }
+        }
+        return allExpandedTags
     }
 
     private resolveFileClassMatchingFilesPaths(): void {


### PR DESCRIPTION
## Summary
Fixes an old regression where nested tags were not being identified when matching note files with fileclasses. The original feature was implemented in #148, but a regression seemed to have been introduced in #444 after migrating the filetag collection logic from depending on dataview to the Obsidian API.

## Problem
**Expected behaviour:**
Given a fileclass defined like so
```yaml
test.md
==============================
---
mapWithTags: true
---
```
A file containing any nested tag with parent tag `#test` (e.g. `#test/nested/arbitrary/depth`) should be mapped to the fileclass.

**Actual behaviour:**
Files with nested tags (like above) are not matched to the `test` fileclass as expected. Only files with the exact tag `#test` are matched.

## Solution
Updated `resolveFileClassMatchingTags()` to consider a candidate file's tags using a new method `getExpandedTags()`, which expands all nested tags within a file into their parent levels. For example:
- Input: `#my/nested/tag`
- Expands to: `#my`, `#my/nested`, `#my/nested/tag`

This is essentially identical to the previous approach implemented in #148, which used the [dataview query](https://blacksmithgu.github.io/obsidian-dataview/annotation/metadata-pages/) `file.tags` to extract a file's tags.

## Testing
Tested on Desktop (I don't use Mobile, but I don't see why it wouldn't work!) on my personal Obsidian vault.
- My `software` fileclass created under `<fileclass_dir>/software.md` with `mapWithTags: true` is now matched to files containing `#software/browsers`
- A nested `software/games` fileclass created under a subpath `<fileclass_dir>/software/games.md` will match a file with `#software/games` and/or `#software/games/emulators`, but not `#software`

## Breaking Changes
Since the current tag-matching behaviour has been in place for over 2 years, users may have adapted their workflows to expect this behaviour. I'm not familiar with how others may be using fileclasses, but if this seems likely to break some users' current setups, it may be worth to introduce this as a toggleable feature turned off by default.
