### PR TITLE
Fix: respect fileclass fields order when inserting missing fields

### DIFF
--- a/src/components/FieldsModal.ts
+++ b/src/components/FieldsModal.ts
@@ -11,7 +11,6 @@ import { FileClassViewManager } from "./FileClassViewManager";
 import { Options as ObjectListOptions, addObjectListItem } from "src/fields/models/ObjectList";
 import { openSettings } from "src/fields/base/BaseSetting";
 import { BaseOptions } from "src/fields/base/BaseField";
-import { sortFileFields } from "src/fileClass/fileClass";
 
 
 export class FieldActions {
@@ -403,14 +402,13 @@ export class FieldsModal extends Modal {
             items.forEach((item: any, index: number) => this.buildObjectListItemContainer(fieldsContainer, field, `${this.indexedPath}[${index}]`))
             this.buildInsertNewItem(field, this.indexedPath)
         } else {
-            const sortedIds = sortFileFields(this.plugin.fieldIndex, this.file).map(f => f.id)
             const fields: Array<ExistingField | Field> = [
                 ...this.existingFields
                     .filter(eF => {
                         if (eF.name === this.plugin.settings.fileClassAlias) return this.plugin.settings.showFileClassSelectInModal
                         else return true
                     }),
-                ...this.missingFields.sort((f1, f2) => sortedIds.indexOf(f1.id) < sortedIds.indexOf(f2.id) ? -1 : 1)
+                ...this.missingFields
             ]
             for (const fieldOrEf of fields) {
                 if (fieldOrEf instanceof ExistingField) {

--- a/src/fileClass/fileClass.ts
+++ b/src/fileClass/fileClass.ts
@@ -536,20 +536,6 @@ export function getSortedRootFields(plugin: MetadataMenu, fileClass: FileClass):
     return sortedFields
 }
 
-export function sortFileFields(index: FieldIndex, file: TFile): Field[] {
-    const fileClasses = index.filesFileClasses.get(file.path) || [];
-    const sortedAttributes: Field[] = []
-    for (const fileClass of fileClasses) {
-        const fileClassFields = index.fileClassesFields.get(fileClass.name) || []
-        const order = fileClass.options.fieldsOrder
-        const sortedFields = order
-            ? fileClassFields.sort((f1, f2) => order.indexOf(f1.id) < order.indexOf(f2.id) ? -1 : 1)
-            : fileClassFields
-        sortedAttributes.push(...sortedFields)
-    }
-    return sortedAttributes
-}
-
 export function getTagNamesFromFrontMatter(_tagNames: string[] | string | undefined): string[] {
     if (Array.isArray(_tagNames)) {
         return _tagNames;

--- a/src/index/FieldIndex.ts
+++ b/src/index/FieldIndex.ts
@@ -508,6 +508,37 @@ export default class FieldIndex extends FieldIndexBuilder {
         return ["Lookup", "Formula"].includes(field.type)
     }
 
+    private sortFieldsByFileClassOrder(fields: Field[], file: TFile): Field[] {
+        /*
+        Sorts a field array according to the fieldsOrder defined in associated fileClasses.
+
+        PREREQUISITE: this.filesFileClasses must be populated for the given file
+        before calling this method. Otherwise returns fields unsorted.
+        */
+
+        const fileClasses = this.filesFileClasses.get(file.path) || []
+        if (!fileClasses.length) return fields
+
+        const combinedOrder: string[] = []
+        for (const fileClass of fileClasses) {
+            const order = fileClass.options.fieldsOrder || []
+            order.forEach(id => {
+                if (!combinedOrder.includes(id)) {
+                    combinedOrder.push(id)
+                }
+            })
+        }
+
+        return fields.sort((f1, f2) => {
+            const idx1 = combinedOrder.indexOf(f1.id)
+            const idx2 = combinedOrder.indexOf(f2.id)
+            if (idx1 === -1 && idx2 === -1) return 0 // Both don't have a defined ordering - preserve original order
+            if (idx1 === -1) return 1                // f1 not ordered - goes after f2
+            if (idx2 === -1) return -1               // f2 not ordered - goes after f1
+            return idx1 - idx2                       // Both are ordered - sort by position
+        })
+    }
+
     private getFilesFields(): number {
         /*
         associates fields to each indexable files according to the mapping
@@ -550,7 +581,8 @@ export default class FieldIndex extends FieldIndexBuilder {
                 fileFields.push(...(fileFieldsFromPath || []).filter(field => !fileFields.map(f => f.id).includes(field.id)))
                 fileFields.push(...(fileFieldsFromGroup || []).filter(field => !fileFields.map(f => f.id).includes(field.id)))
                 fileFields.push(...(fileFieldsFromQuery || []).filter(field => !fileFields.map(f => f.id).includes(field.id)))
-                this.filesFields.set(f.path, fileFields);
+                fileFields = this.sortFieldsByFileClassOrder(fileFields, f)
+                this.filesFields.set(f.path, fileFields)
                 const filesLookupAndFormulasFields: Field[] = fileFields.filter(f => this.isLookupOrFormula(f))
                 filesLookupAndFormulasFields.push(...(fileFieldsFromTag || []).filter(field => !filesLookupAndFormulasFields.map(f => f.id).includes(field.id) && this.isLookupOrFormula(field)))
                 filesLookupAndFormulasFields.push(...(fileFieldsFromPath || []).filter(field => !filesLookupAndFormulasFields.map(f => f.id).includes(field.id) && this.isLookupOrFormula(field)))
@@ -559,11 +591,12 @@ export default class FieldIndex extends FieldIndexBuilder {
                 if (filesLookupAndFormulasFields.length) this.filesLookupsAndFormulasFields.set(f.path, filesLookupAndFormulasFields)
             } else if (this.fieldsFromGlobalFileClass.length) {
                 fileFields = this.fieldsFromGlobalFileClass
+                this.filesFileClasses.set(f.path, [this.fileClassesName.get(this.settings.globalFileClass!)!])
+                this.filesFileClassesNames.set(f.path, [this.settings.globalFileClass!])
+                fileFields = this.sortFieldsByFileClassOrder(fileFields, f)
                 this.filesFields.set(f.path, fileFields)
                 const filesLookupAndFormulasFields = this.fieldsFromGlobalFileClass.filter(f => this.isLookupOrFormula(f))
                 if (filesLookupAndFormulasFields.length) this.filesLookupsAndFormulasFields.set(f.path, this.fieldsFromGlobalFileClass.filter(f => this.isLookupOrFormula(f)))
-                this.filesFileClasses.set(f.path, [this.fileClassesName.get(this.settings.globalFileClass!)!])
-                this.filesFileClassesNames.set(f.path, [this.settings.globalFileClass!])
             } else {
                 fileFields = this.plugin.presetFields.map(prop => {
                     const property = new (buildEmptyField(this.plugin, undefined))


### PR DESCRIPTION
## Summary
**Fixes:** #618, #731
**Partially addresses:** #491

## Problem
The "insert missing fields" actions currently add fields in the order they were originally defined, rather than the order configured by the user in the FileClass settings UI. This contradicts the [documented behaviour of inserting missing fields](https://mdelobelle.github.io/metadatamenu/controls/#insert-all-missing-fields), and as reported in the linked issues, this behavior is unintuitive and inconvenient.

## Root Cause
`FieldIndex.getFilesFields()` populates `filesFields` from the frontmatter `fields` array, which is populated in creation order. The ordering of fileclass fields is saved separately in `fieldsOrder`, however, this is never applied during field indexing, so downstream consumers operate on fields sorted in the unintuitive creation order.

## Solution
Fields now get sorted according to the fileclass-defined `fieldsOrder` during `FieldIndex.getFilesFields()`, before they are stored in `filesFields`.

As a result, all consumers of `filesFields` now receive fields in the expected order:
* Missing-field insertion respects the user-configured FileClass ordering
* Additionally, this also improves the `InsertFieldSuggestModal` displayed when clicking the metadata button from a note's properties section – the modal will show fields in expected order, rather than the raw creation order