### PR TITLE
fix: FileClassCodeBlockManager rendering + feat: Multi bulk edit modes & drag-select

### DIFF
--- a/src/components/FileClassCodeBlockManager.ts
+++ b/src/components/FileClassCodeBlockManager.ts
@@ -1,5 +1,5 @@
 import MetadataMenu from "main";
-import { MarkdownPostProcessorContext, MarkdownRenderChild, parseYaml } from "obsidian";
+import { EventRef, MarkdownPostProcessorContext, MarkdownRenderChild, parseYaml } from "obsidian";
 import { FileClass } from "src/fileClass/fileClass";
 import { FileClassCodeBlockView } from "src/fileClass/views/fileClassCodeBlockView";
 
@@ -15,6 +15,7 @@ export class FileClassCodeBlockManager extends MarkdownRenderChild {
     public tableId: string
     public isLoaded: boolean = false
     public showAddField: boolean = false
+    private indexEventRef: EventRef | null = null
 
     constructor(
         public plugin: MetadataMenu,
@@ -28,36 +29,60 @@ export class FileClassCodeBlockManager extends MarkdownRenderChild {
     public build() {
         const el = this.containerEl
         const source = this.source
-        el.replaceChildren()
-        el.addClass("metadata-menu")
-        el.addClass("fileclass-codeblock-view")
-        const container = el.createDiv({ cls: "fv-table" })
-        const header = container.createDiv({ cls: "options" })
-        const paginationContainer = header.createDiv({ cls: "pagination" });
-        this.tableId = `table-container-${Math.floor(Date.now())}`
-        const tableContainer = container.createDiv({ attr: { id: this.tableId } })
-        container.createDiv()
         try {
             const content = parseYaml(source)
             const fileClassName = content[this.plugin.settings.fileClassAlias]
             const selectedView = content.view?.toString() as string | undefined
             this.fileClass = this.plugin.fieldIndex.fileClassesName.get(fileClassName)
             if (this.fileClass) {
+                // Only modify DOM after confirming fileClass exists
+                // to prevent destroying page content on failure
+                el.replaceChildren()
+                el.addClass("metadata-menu")
+                el.addClass("fileclass-codeblock-view")
+                const container = el.createDiv({ cls: "fv-table" })
+                const header = container.createDiv({ cls: "options" })
+                const paginationContainer = header.createDiv({ cls: "pagination" });
+                this.tableId = `table-container-${Math.floor(Date.now())}`
+                const tableContainer = container.createDiv({ attr: { id: this.tableId } })
+                container.createDiv()
                 this.itemsPerPage = content["files per page"] || this.fileClass.options.limit || this.plugin.settings.tableViewMaxRecords
                 this.startAtItem = content["start"] || 0
                 this.showAddField = content["showAddField"] === true || false
                 this.fileClassCodeBlockView = new FileClassCodeBlockView(this, this.tableId, this.fileClass, paginationContainer, tableContainer, selectedView, this.ctx)
                 this.fileClassCodeBlockView.fileClassDataviewTable.limit = this.itemsPerPage
-                this.plugin.registerMarkdownPostProcessor((el, ctx) => {
+                // Call buidFileClassViewBtn directly instead of via
+                // registerMarkdownPostProcessor to avoid rendering conflicts
+                // in reading view
+                try {
                     this.fileClassCodeBlockView.fileClassDataviewTable.buidFileClassViewBtn()
-                })
+                } catch (e) {
+                    // buidFileClassViewBtn may fail if DOM is not ready yet; safe to ignore
+                }
                 this.fileClassCodeBlockView.update(this.itemsPerPage, this.startAtItem)
                 this.isLoaded = true
+                this.unregisterIndexEvent()
             } else {
-                el.setText(`${fileClassName} isn't a proper fileclass`)
+                // fileClass may not be indexed yet; listen for the indexing
+                // event and rebuild when it fires (same pattern as
+                // FileClassViewManager)
+                if (!this.indexEventRef) {
+                    this.indexEventRef = this.plugin.app.metadataCache.on(
+                        "metadata-menu:fileclass-indexed",
+                        () => { this.build() }
+                    )
+                    this.registerEvent(this.indexEventRef)
+                }
             }
         } catch (e) {
             el.setText(e)
+        }
+    }
+
+    private unregisterIndexEvent() {
+        if (this.indexEventRef) {
+            this.plugin.app.metadataCache.offref(this.indexEventRef)
+            this.indexEventRef = null
         }
     }
 
@@ -66,6 +91,7 @@ export class FileClassCodeBlockManager extends MarkdownRenderChild {
     }
 
     onunload(): void {
+        this.unregisterIndexEvent()
         this.plugin.codeBlockListManager.removeChild(this)
     }
 

--- a/src/fields/Field.ts
+++ b/src/fields/Field.ts
@@ -8,7 +8,7 @@ import FCSM from "src/options/FieldCommandSuggestModal";
 import { FieldType, getFieldModal, multiTypes, objectTypes, rootOnlyTypes, getFieldClass, getDefaultOptions, MultiDisplayType } from "./Fields"
 import { FieldParam, IFieldBase, BaseOptions, isFieldOptions } from "./base/BaseField"
 import { postValues } from "src/commands/postValues"
-import { IBaseValueModal, MultiTargetModificationConfirmModal } from "./base/BaseModal"
+import { BulkEditMode, IBaseValueModal, MultiTargetModificationConfirmModal } from "./base/BaseModal"
 import { ExistingField } from "./ExistingField"
 import { Constructor } from "src/typings/types"
 import { FieldActions } from "src/components/FieldsModal"
@@ -534,7 +534,7 @@ export interface IFieldManager<T, O extends BaseOptions> extends IField<O> {
     asBlockquote?: boolean,
     previousModal?: IObjectBaseModal<Target>
     openModal: () => void;
-    save: (value?: any) => Promise<void>
+    save: (value?: any, mode?: import("./base/BaseModal").BulkEditMode) => Promise<void>
     goToPreviousModal: () => Promise<void>
 }
 
@@ -641,13 +641,13 @@ export function FieldValueManager<O extends BaseOptions, F extends Constructor<I
             this.plugin.fieldIndex.updatedManagedField = undefined
         }
 
-        public async save(value?: any) {
+        public async save(value?: any, mode?: BulkEditMode) {
             if (value !== undefined) this.value = value
             if (isSingleTargeted(this)) {
                 if (this.previousModal) this.plugin.fieldIndex.updatedManagedField = this
                 await postValues(plugin, [{ indexedPath: this.indexedPath || this.id, payload: { value: `${this.value || ""}` } }], this.target, this.lineNumber, this.asList, this.asBlockquote)
             } else if (isMultiTargeted(this)) {
-                new MultiTargetModificationConfirmModal(this).open()
+                new MultiTargetModificationConfirmModal(this, mode || 'overwrite').open()
             }
         }
     }

--- a/src/fields/models/Multi.ts
+++ b/src/fields/models/Multi.ts
@@ -2,7 +2,7 @@
 import MetadataMenu from "main";
 import * as AbstractList from "./abstractModels/AbstractList"
 import { ISettingsModal as IBaseSettingsModal } from "../base/BaseSetting";
-import { ActionLocation, IField, IFieldManager, Target, fieldValueManager, isSingleTargeted } from "../Field";
+import { ActionLocation, IField, IFieldManager, Target, fieldValueManager, isMultiTargeted, isSingleTargeted } from "../Field";
 import { getFieldModal } from "../Fields";
 import { ButtonComponent, TFile, setIcon } from "obsidian";
 import { getLink } from "src/utils/parser";
@@ -135,14 +135,43 @@ export function valueModal(managedField: IFieldManager<Target, Options>, plugin:
         }
 
         buildConfirm(footerActionsContainer: HTMLDivElement) {
-            const infoContainer = footerActionsContainer.createDiv({ cls: "info" })
-            infoContainer.setText("Alt+Enter to save")
-            const confirmButton = new ButtonComponent(footerActionsContainer)
-            confirmButton.setIcon("checkmark")
-            confirmButton.onClick(async () => {
-                await this.save();
-                this.close()
-            })
+            if (isMultiTargeted(managedField)) {
+                const appendButton = new ButtonComponent(footerActionsContainer)
+                appendButton.setIcon("list-plus")
+                appendButton.setTooltip("Add to existing values")
+                appendButton.onClick(async () => {
+                    this.saved = true
+                    managedField.save(this.selectedOptions.join(", "), 'append')
+                    this.close()
+                })
+
+                const overwriteButton = new ButtonComponent(footerActionsContainer)
+                overwriteButton.setIcon("replace")
+                overwriteButton.setTooltip("Replace all values")
+                overwriteButton.onClick(async () => {
+                    this.saved = true
+                    managedField.save(this.selectedOptions.join(", "), 'overwrite')
+                    this.close()
+                })
+
+                const removeButton = new ButtonComponent(footerActionsContainer)
+                removeButton.setIcon("list-minus")
+                removeButton.setTooltip("Remove selected values")
+                removeButton.onClick(async () => {
+                    this.saved = true
+                    managedField.save(this.selectedOptions.join(", "), 'remove')
+                    this.close()
+                })
+            } else {
+                const infoContainer = footerActionsContainer.createDiv({ cls: "info" })
+                infoContainer.setText("Alt+Enter to save")
+                const confirmButton = new ButtonComponent(footerActionsContainer)
+                confirmButton.setIcon("checkmark")
+                confirmButton.onClick(async () => {
+                    await this.save();
+                    this.close()
+                })
+            }
         }
     }
 }

--- a/src/fields/models/abstractModels/AbstractList.ts
+++ b/src/fields/models/abstractModels/AbstractList.ts
@@ -2,7 +2,7 @@ import { ButtonComponent, DropdownComponent, TFile, TextAreaComponent, TextCompo
 import { BaseOptions } from "../../base/BaseField"
 import { ISettingsModal } from "../../base/BaseSetting"
 import { FileSuggest } from "src/suggester/FileSuggester"
-import { ActionLocation, IField, IFieldManager, Target, baseDisplayValue, fieldValueManager, isFieldActions, isSingleTargeted, isSuggest, removeValidationError, setValidationError } from "../../Field"
+import { ActionLocation, IField, IFieldManager, Target, baseDisplayValue, fieldValueManager, isFieldActions, isMultiTargeted, isSingleTargeted, isSuggest, removeValidationError, setValidationError } from "../../Field"
 import MetadataMenu from "main"
 import { IBaseValueModal, basicSuggestModal } from "../../base/BaseModal"
 import { cleanActions } from "src/utils/modals"
@@ -375,7 +375,11 @@ export function valueModal(managedField: IFieldManager<Target, Options>, plugin:
         buildConfirm(footerActionsContainer: HTMLDivElement) { }
 
         async clearValues() {
-            this.managedField.save("")
+            if (isMultiTargeted(this.managedField)) {
+                this.managedField.save("", 'clear')
+            } else {
+                this.managedField.save("")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

### Fix: FileClassCodeBlockManager rendering issues (commit 1)

Fixes three bugs in `FileClassCodeBlockManager.build()` that cause rendering failures for `mdm` codeblocks:

- **Page destruction**: `el.replaceChildren()` and `el.addClass()` were called before verifying that the fileClass exists in the index. Moved DOM manipulation inside the `if (this.fileClass)` block.
- **Reading view rendering conflict**: `registerMarkdownPostProcessor()` was called inside `build()`, triggering recursive rendering conflicts. Replaced with a direct call to `buidFileClassViewBtn()` wrapped in try-catch.
- **Indexing timing**: When `fieldIndex` had not finished processing, the block displayed a permanent error. Now listens for `metadata-menu:fileclass-indexed` event and rebuilds automatically.

### Feat: Multi field bulk edit modes (commit 2)

When bulk-editing Multi (list) fields via MDM table header click on checked files, users can now choose between **4 modes**:

| Mode | Icon | Behavior |
|------|------|----------|
| **Append** | `list-plus` | Keep existing values, add only new ones (no duplicates) |
| **Overwrite** | `replace` | Replace entire list with selected values (existing behavior) |
| **Remove** | `list-minus` | Remove only selected values from each file (keep others) |
| **Clear** | `eraser` | Remove all values from all selected files |

The confirmation modal shows **per-file preview** (`current → result`) for append and remove modes.

### Feat: Drag-to-select checkboxes in MDM table (commit 3)

Users can now **mousedown + drag** across multiple checkboxes to quickly select/deselect files in one sweep ("paint select" pattern), instead of clicking each checkbox individually.

- `mousedown` on a checkbox starts drag mode and records direction (check/uncheck)
- `mouseenter` on other checkboxes while dragging applies the same direction
- `mouseup` anywhere ends drag mode
- Header select-all checkbox behavior unchanged

## Files changed

| File | Change |
|------|--------|
| `src/fileClass/FileClassCodeBlockManager.ts` | Fix rendering bugs |
| `src/fields/base/BaseModal.ts` | `BulkEditMode` type, mode-aware confirm modal |
| `src/fields/Field.ts` | `save()` with optional mode parameter |
| `src/fields/models/Multi.ts` | Multi-targeted action buttons |
| `src/fields/models/abstractModels/AbstractList.ts` | Mode-aware clear |
| `src/fileClass/views/tableViewComponents/fileClassDataviewTable.ts` | Drag-to-select |

## Related

- Relates to #667

## Test plan

- [ ] `mdm` codeblocks render correctly on startup (no page destruction)
- [ ] Bulk edit Multi field: Append / Overwrite / Remove / Clear all work
- [ ] Single-file Multi field edit works as before (no regression)
- [ ] Drag-select: mousedown + drag across checkboxes selects multiple files
- [ ] Drag-deselect: same gesture on checked boxes unchecks them
- [ ] Single click on checkbox still works normally
- [ ] Header select-all unchanged