### PR TITLE
feat: separate bulk-edit trigger from column sort

### DIFF
--- a/src/assets/css/fileclass.scss
+++ b/src/assets/css/fileclass.scss
@@ -514,6 +514,19 @@
                 .checkbox-toggler{
                     display: flex;
                     align-items: center;
+                    padding: 0 8px;
+                    cursor: pointer;
+                    svg { width: 22px; height: 22px; }
+                }
+                .bulk-apply-btn{
+                    display: flex;
+                    align-items: center;
+                    padding: 0 6px;
+                    cursor: pointer;
+                    border-radius: 4px;
+                    opacity: 0.7;
+                    svg { width: 22px; height: 22px; }
+                    &:hover { opacity: 1; background: var(--background-modifier-hover); }
                 }
                 &.first-col-header-cell{
                     left: 0;

--- a/src/fields/base/BaseModal.ts
+++ b/src/fields/base/BaseModal.ts
@@ -224,10 +224,10 @@ export class MultiTargetModificationConfirmModal<O extends BaseOptions> extends 
         new ButtonComponent(footer)
             .setButtonText("Confirm")
             .setWarning()
-            .onClick(() => {
+            .onClick(async () => {
                 for (const target of targets) {
                     const finalValue = this.computeFinalValue(target)
-                    postValues(
+                    await postValues(
                         this.managedField.plugin,
                         [{ indexedPath: this.managedField.id, payload: { value: finalValue } }],
                         target.filePath,

--- a/src/fileClass/views/tableViewComponents/fileClassDataviewTable.ts
+++ b/src/fileClass/views/tableViewComponents/fileClassDataviewTable.ts
@@ -159,6 +159,9 @@ export class FileClassDataviewTable {
             for (const toggler of table.querySelectorAll(".checkbox-toggler")) {
                 (toggler as HTMLElement).parentElement?.removeChild(toggler)
             }
+            for (const applyBtn of table.querySelectorAll(".bulk-apply-btn")) {
+                (applyBtn as HTMLElement).parentElement?.removeChild(applyBtn)
+            }
         }
 
         const processFilesFieldChange = (dvTable: FileClassDataviewTable, selectedFiles: string[], allFilesSelected: boolean, columndId: string) => {
@@ -264,22 +267,33 @@ export class FileClassDataviewTable {
                     column.createDiv({ cls: "spacer" })
                     const toggleButtonContainer = column.createDiv({ cls: "checkbox-toggler" })
                     setIcon(toggleButtonContainer, "list-todo")
-
-                }
-
-                column.onclick = (e) => {
-                    if (index === "0") {
+                    toggleButtonContainer.onclick = (e) => {
+                        e.stopPropagation()
                         const cells = table.querySelectorAll('.modifier-selector') as NodeListOf<HTMLTableCellElement>
                         for (const cell of cells) {
                             const input = cell.find("input")
                             if (input && !(input as HTMLElement & { checkVisibility: () => boolean }).checkVisibility()) cell.show()
                             else cell.hide()
                         }
-                    } else {
+                        const applyBtns = table.querySelectorAll('.bulk-apply-btn') as NodeListOf<HTMLElement>
+                        const anyCheckboxVisible = table.querySelector('.modifier-selector input') &&
+                            (table.querySelector('.modifier-selector input') as HTMLElement & { checkVisibility: () => boolean }).checkVisibility()
+                        for (const btn of applyBtns) {
+                            if (anyCheckboxVisible) btn.show()
+                            else btn.hide()
+                        }
+                    }
+                } else {
+                    const applyBtn = column.createDiv({ cls: "bulk-apply-btn" })
+                    setIcon(applyBtn, "pencil")
+                    applyBtn.onclick = (e) => {
+                        e.stopPropagation()
                         const columnId = (column.querySelector('span.column-id') as HTMLInputElement).id
                         if (selectedFiles.length || allFilesSelected) processFilesFieldChange(dvTable, selectedFiles, allFilesSelected, columnId)
                     }
+                    applyBtn.hide()
                 }
+
             }
         }
 


### PR DESCRIPTION
## Summary
Follow-up to #787. Improves the bulk edit UX in MDM fileclass table views:

- **Separate bulk-edit from sort**: Column header click now only sorts. A dedicated pencil icon button triggers bulk edit for each column, preventing accidental edits when sorting.
- **Checkbox toggle isolation**: The checkbox toggler (`list-todo` icon) uses `stopPropagation()` to avoid triggering column sort when toggling row selection.
- **Pencil buttons auto-show/hide**: Bulk-apply pencil buttons appear only when checkboxes are visible, keeping the UI clean.
- **Async safety for bulk edit confirm**: `MultiTargetModificationConfirmModal` confirm handler now uses `async/await` to process files sequentially, preventing potential race conditions when editing multiple files.
- **CSS cleanup**: Unified icon sizes (22px), added hover styles for bulk-apply buttons, added `cleanTable` cleanup for `.bulk-apply-btn` elements.

## Files Changed
- `src/fileClass/views/tableViewComponents/fileClassDataviewTable.ts` — UI logic refactor
- `src/assets/css/fileclass.scss` — Styles for `.bulk-apply-btn` and `.checkbox-toggler`
- `src/fields/base/BaseModal.ts` — async/await in confirm handler

## Test plan
- [ ] Open a fileclass table view with multiple fields
- [ ] Click column headers → should only sort (no bulk edit modal)
- [ ] Toggle checkboxes → pencil icons appear on each column
- [ ] Click pencil icon → bulk edit modal opens for that column
- [ ] Hide checkboxes → pencil icons disappear
- [ ] Bulk edit multiple files → verify no race conditions (fields not cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)