### PR TITLE
Update `Note.renderValueString()` in note.ts

### DIFF
--- a/src/note/lineNode.ts
+++ b/src/note/lineNode.ts
@@ -236,6 +236,7 @@ export class LineNode {
             !(
                 this.field.type === "JSON"
                 || this.field.type === "YAML"
+                || this.field.type === "Formula"
                 || this.field.type === "Lookup"
                 || this.field.type === "Multi"
                 || this.field.type === "MultiFile"

--- a/src/note/note.ts
+++ b/src/note/note.ts
@@ -48,12 +48,15 @@ export class Note {
     public renderValueString(_rawValue: string, fieldType?: FieldType, indentationLevel: number = 0): string {
         if (_rawValue) {
             if (_rawValue.startsWith("[[") || _rawValue.startsWith("![[")) {
-                return `"${_rawValue}"`
-            } else if (_rawValue.startsWith("#")) {
+                return `"${_rawValue}"`;
+            } else if(_rawValue.startsWith("#")) {
                 return `${_rawValue}`;
             } else if (fieldType && rawObjectTypes.includes(fieldType)) {
                 const indentation = `\n${"  ".repeat(indentationLevel + 1)}`
                 return `${indentation}${_rawValue.split("\n").join(indentation)}`;
+            } else if (fieldType && fieldType === "Formula" && _rawValue.startsWith("[")) {
+                const indentation = "\n  - ";
+                return `${indentation}${_rawValue.slice(1,-1).split(/(?<="),/).map((v) => v.trim()).join(indentation)}`;
             } else {
                 //return parseYaml(_rawValue)
                 return [_rawValue, true, false].includes(parseYaml(_rawValue)) || !isNaN(parseFloat(_rawValue)) ? parseYaml(_rawValue) : `"${_rawValue}"`;


### PR DESCRIPTION
to allow correct rendering of formula fields when the value is an array.

Before, arrays would be enclosed in double quotes, which made Obsidian think that the value was a string that happened to have commas in it when it should have been an array instead.


Use the indented list style to render arrays, as it turns out, Obsidian will automatically reformat frontmatter fields with type 'list' to the indented list style when the value was previously an inline array. This reformatting is done when another frontmatter field is modified (e.g., removed in case of a list style field).
This change of the field value subsequently results in invalid YAML being generated for the frontmatter because MetadataMenu will add the inline array style value where Obsidian had put the indented list style. The only way around this IMO is to force the indented list style for formula field values that are arrays.

Would fix #782, and fix #486.